### PR TITLE
fixes error while uploading profile images

### DIFF
--- a/classes/AutoID.php
+++ b/classes/AutoID.php
@@ -431,7 +431,10 @@ class AutoID
 
     public static function addFile(\Kirby\Cms\File $file): bool
     {
-        return static::pushEntries(static::indexPage($file->page()));
+        if ($file->page()) {
+            return static::pushEntries(static::indexPage($file->page()));
+        }
+        return false;
     }
 
     public static function removeFile(\Kirby\Cms\File $file): bool


### PR DESCRIPTION
Uploading an profile image for a user causes the following error:

> Argument 1 passed to Bnomei\AutoID::indexPage() must be an instance of Kirby\Cms\Page, null given, called in …/vendor/bnomei/kirby3-autoid/classes/AutoID.php on line 434

The problem was that `$file->page()` does not exist while in user context.

Tested with `kirby3-autoid 1.2.4` and `Kirby 3.0.0`