### PR TITLE
feat: automatically run unit tests against latest version of kirby

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Unit Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    - cron:  '0 2 * * *' # run at 2 AM UTC
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.2'
+          tools: composer
+
+      - name: Install
+        run: composer install
+
+      # update kirby to latest release of version 3 (includes release candidates!)
+      # https://semver.mwl.be/#!?package=getkirby%2Fcms&version=3.*&minimum-stability=RC
+      - name: Update Kirby Core
+        run: composer require getkirby/cms:"3.*@RC"
+
+      - name: Run Tests
+        run: composer test


### PR DESCRIPTION
As discussed in Slack this PR will add automated test runs against the latest version of Kirby, including [release candidates](https://semver.mwl.be/#!?package=getkirby%2Fcms&version=3.*&minimum-stability=RC). All tests are executed after someone opens a _pull request_, a _merge_ on main branch and _every night_ at 2AM (UTC).

You can review a successful run here: https://github.com/gearsdigital/kirby3-autoid/runs/918395799?check_suite_focus=true

If you have any questions don't hesitate to ask me 😊