### PR TITLE
Fix error thrown for files, which are children of `$site`

### DIFF
--- a/classes/AutoIDProcess.php
+++ b/classes/AutoIDProcess.php
@@ -218,8 +218,8 @@ final class AutoIDProcess
     private function itemFromFile($object): array
     {
         return [
-            'page' => $object->page()->id(),
-            'diruri' => $object->page()->diruri() . '@' . $object->filename(),
+            'page' => $object->parent()->id(),
+            'diruri' => $object->parent()->diruri() . '@' . $object->filename(),
             'filename' => $object->filename(),
             'modified' => $object->modified(),
             'kind' => AutoIDItem::KIND_FILE,


### PR DESCRIPTION
Use `parent()` instead of `page()`, because it also works for site’s files.