### PR TITLE
feat: allow label and help props in autoid field

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,12 +3,15 @@
  */
 
 panel.plugin('bnomei/autoid', {
-    fields: {
-      autoid: {
-        props: {
-          value: String
-        },
-        template: '<k-text-field v-model="value" name="autoid" label="AutoID" :disabled="true" />'
-      }
+  fields: {
+    autoid: {
+      props: {
+        value: String,
+        label: String,
+        help: String,
+      },
+      template:
+        '<k-text-field v-model="value" :label="label" :help="help" name="autoid" :disabled="true" />'
     }
-  });
+  }
+});


### PR DESCRIPTION
closes #73 

- allows field of type `autoid` to have `label` and `help`props